### PR TITLE
fix: remove conflicts while building in x64_x86

### DIFF
--- a/SkiaUnity/Assets/SkiaSharp/Library/win-x86/libHarfBuzzSharp.dll.meta
+++ b/SkiaUnity/Assets/SkiaSharp/Library/win-x86/libHarfBuzzSharp.dll.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: c60a5b29741504feb8db096739a2e9cd
 PluginImporter:
   externalObjects: {}
-  serializedVersion: 2
+  serializedVersion: 3
   iconMap: {}
   executionOrder: {}
   defineConstraints: []
@@ -11,64 +11,44 @@ PluginImporter:
   isExplicitlyReferenced: 0
   validateReferences: 1
   platformData:
-  - first:
-      : Any
-    second:
-      enabled: 0
-      settings:
-        Exclude Android: 1
-        Exclude Editor: 0
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
-        Exclude Win: 0
-        Exclude Win64: 0
-        Exclude iOS: 1
-  - first:
-      Android: Android
-    second:
+    Android:
       enabled: 0
       settings:
         CPU: ARMv7
-  - first:
-      Any: 
-    second:
+    Any:
       enabled: 0
-      settings: {}
-  - first:
-      Editor: Editor
-    second:
-      enabled: 1
       settings:
-        CPU: x86
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 0
+        Exclude Win64: 1
+        Exclude iOS: 1
+    Editor:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
         OS: Windows
-  - first:
-      Standalone: Linux64
-    second:
+    Linux64:
       enabled: 1
       settings:
         CPU: None
-  - first:
-      Standalone: OSXUniversal
-    second:
+    OSXUniversal:
       enabled: 1
       settings:
         CPU: None
-  - first:
-      Standalone: Win
-    second:
+    Win:
       enabled: 1
       settings:
         CPU: x86
-  - first:
-      Standalone: Win64
-    second:
-      enabled: 1
+    Win64:
+      enabled: 0
       settings:
         CPU: None
-  - first:
-      iPhone: iOS
-    second:
+    iOS:
       enabled: 0
       settings:
         AddToEmbeddedBinaries: false

--- a/SkiaUnity/Assets/SkiaSharp/Library/win-x86/libSkiaSharp.dll.meta
+++ b/SkiaUnity/Assets/SkiaSharp/Library/win-x86/libSkiaSharp.dll.meta
@@ -26,8 +26,9 @@ PluginImporter:
         Exclude Linux64: 0
         Exclude LinuxUniversal: 0
         Exclude OSXUniversal: 0
+        Exclude WebGL: 1
         Exclude Win: 0
-        Exclude Win64: 0
+        Exclude Win64: 1
         Exclude iOS: 1
     Editor:
       enabled: 0
@@ -48,9 +49,9 @@ PluginImporter:
       settings:
         CPU: AnyCPU
     Win64:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86_64
+        CPU: None
     iOS:
       enabled: 0
       settings:


### PR DESCRIPTION
Fixes the issues with building caused by meta file issues in later unity versions