### PR TITLE
fix: key typeface caches by EntityId for Unity 6.3

### DIFF
--- a/SkiaUnity/Assets/SkiaSharp/Runtime/HB_TEXTBlock.cs
+++ b/SkiaUnity/Assets/SkiaSharp/Runtime/HB_TEXTBlock.cs
@@ -7,6 +7,7 @@ using UnityEngine.Events;
 using UnityEngine.UI;
 using Topten.RichTextKit;
 using TextAlignment = Topten.RichTextKit.TextAlignment;
+#pragma warning disable CS0618
 
 namespace SkiaSharp.Unity.HB {
 	public enum HBColorFormat {
@@ -628,7 +629,7 @@ namespace SkiaSharp.Unity.HB {
 				var fontBytes = GetFontBytes();
 				if (fontBytes == null) return;
 				if (skTypeface == null) {
-					int key = font.GetEntityId();
+					int key = font.GetInstanceID();
 					if (!_typefaceCache.ContainsKey(key)) {
 						SKData copy = SKData.CreateCopy(fontBytes);
 						_typefaceCache[key] = SKTypeface.FromData(copy);
@@ -641,7 +642,7 @@ namespace SkiaSharp.Unity.HB {
 					_typefaceCacheRegistered = true;
 				}
 				// Reuse FontMapper if typeface hasn't changed
-				int typefaceKey = font.GetEntityId();
+				int typefaceKey = font.GetInstanceID();
 				if (_cachedFontMapper == null || _cachedFontMapperKey != typefaceKey) {
 					_cachedFontMapper = new FontMapper(skTypeface);
 					_cachedFontMapperKey = typefaceKey;
@@ -1549,7 +1550,7 @@ namespace SkiaSharp.Unity.HB {
 
 		public virtual void RefreshFontFamily() {
 			if (font != null) {
-				int key = font.GetEntityId();
+				int key = font.GetInstanceID();
 				if (!_typefaceCache.ContainsKey(key)) {
 					var fontBytes = GetFontBytes();
 					if (fontBytes == null) return;

--- a/SkiaUnity/Assets/SkiaSharp/Runtime/HB_TEXTBlock.cs
+++ b/SkiaUnity/Assets/SkiaSharp/Runtime/HB_TEXTBlock.cs
@@ -7,7 +7,6 @@ using UnityEngine.Events;
 using UnityEngine.UI;
 using Topten.RichTextKit;
 using TextAlignment = Topten.RichTextKit.TextAlignment;
-#pragma warning disable CS0618
 
 namespace SkiaSharp.Unity.HB {
 	public enum HBColorFormat {
@@ -122,9 +121,9 @@ namespace SkiaSharp.Unity.HB {
 		protected string pattern = @"(https?://\S+|www\.\S+)";
 		protected Regex regex;
 		protected SKTypeface skTypeface;
-		private static readonly Dictionary<int, SKTypeface> _typefaceCache = new();
-		private static readonly Dictionary<int, int> _typefaceRefCounts = new();
-		private int _typefaceCacheKey;
+		private static readonly Dictionary<EntityId, SKTypeface> _typefaceCache = new();
+		private static readonly Dictionary<EntityId, int> _typefaceRefCounts = new();
+		private EntityId _typefaceCacheKey;
 		private bool _typefaceCacheRegistered;
 		protected RectTransform rectTransform;
 		protected float currentWidth, currentHeight, currentPreferdWidth = 0, currentPreferdHeight;
@@ -133,7 +132,7 @@ namespace SkiaSharp.Unity.HB {
 
 		// Cached objects to avoid per-render allocations
 		private FontMapper _cachedFontMapper;
-		private int _cachedFontMapperKey;
+		private EntityId _cachedFontMapperKey;
 		private Style _linkStyle;
 		private Style _cachedSpacerStyle;
 		private float _cachedSpacerFontSize;
@@ -629,7 +628,7 @@ namespace SkiaSharp.Unity.HB {
 				var fontBytes = GetFontBytes();
 				if (fontBytes == null) return;
 				if (skTypeface == null) {
-					int key = font.GetInstanceID();
+					EntityId key = font.GetEntityId();
 					if (!_typefaceCache.ContainsKey(key)) {
 						SKData copy = SKData.CreateCopy(fontBytes);
 						_typefaceCache[key] = SKTypeface.FromData(copy);
@@ -642,7 +641,7 @@ namespace SkiaSharp.Unity.HB {
 					_typefaceCacheRegistered = true;
 				}
 				// Reuse FontMapper if typeface hasn't changed
-				int typefaceKey = font.GetInstanceID();
+				EntityId typefaceKey = font.GetEntityId();
 				if (_cachedFontMapper == null || _cachedFontMapperKey != typefaceKey) {
 					_cachedFontMapper = new FontMapper(skTypeface);
 					_cachedFontMapperKey = typefaceKey;
@@ -1550,7 +1549,7 @@ namespace SkiaSharp.Unity.HB {
 
 		public virtual void RefreshFontFamily() {
 			if (font != null) {
-				int key = font.GetInstanceID();
+				EntityId key = font.GetEntityId();
 				if (!_typefaceCache.ContainsKey(key)) {
 					var fontBytes = GetFontBytes();
 					if (fontBytes == null) return;

--- a/SkiaUnity/Assets/SkiaSharp/Runtime/HB_TEXTBlock.cs
+++ b/SkiaUnity/Assets/SkiaSharp/Runtime/HB_TEXTBlock.cs
@@ -628,7 +628,7 @@ namespace SkiaSharp.Unity.HB {
 				var fontBytes = GetFontBytes();
 				if (fontBytes == null) return;
 				if (skTypeface == null) {
-					int key = font.GetInstanceID();
+					int key = font.GetEntityId();
 					if (!_typefaceCache.ContainsKey(key)) {
 						SKData copy = SKData.CreateCopy(fontBytes);
 						_typefaceCache[key] = SKTypeface.FromData(copy);
@@ -641,7 +641,7 @@ namespace SkiaSharp.Unity.HB {
 					_typefaceCacheRegistered = true;
 				}
 				// Reuse FontMapper if typeface hasn't changed
-				int typefaceKey = font.GetInstanceID();
+				int typefaceKey = font.GetEntityId();
 				if (_cachedFontMapper == null || _cachedFontMapperKey != typefaceKey) {
 					_cachedFontMapper = new FontMapper(skTypeface);
 					_cachedFontMapperKey = typefaceKey;
@@ -1549,7 +1549,7 @@ namespace SkiaSharp.Unity.HB {
 
 		public virtual void RefreshFontFamily() {
 			if (font != null) {
-				int key = font.GetInstanceID();
+				int key = font.GetEntityId();
 				if (!_typefaceCache.ContainsKey(key)) {
 					var fontBytes = GetFontBytes();
 					if (fontBytes == null) return;


### PR DESCRIPTION
fix: key typeface caches by EntityId for Unity 6.3
Unity 6.3 (6000.5) marks Object.GetInstanceID() as [Obsolete(error: true)],
so it raises CS0619 rather than a suppressible warning. Switching the call
to GetEntityId() alone is not enough: the implicit EntityId -> int
conversion is obsolete-as-error too, and is slated for removal, so
assigning the result to an int just moves the error.